### PR TITLE
Make URL validation optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ keywords = ["http", "https", "client", "request"]
 categories = ["web-programming::http-client"]
 repository = "https://github.com/WilliamVenner/sysreq"
 
+[features]
+default = ["validate"]
+validate = ["url"]
+
 [dependencies]
-url = "2"
+url = { version = "2", optional = true }
 
 [dev-dependencies]
 reqwest = { version = "0", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }

--- a/src/clients/curl.rs
+++ b/src/clients/curl.rs
@@ -10,7 +10,7 @@ impl SystemHttpClientInterface for cURL {
 			.arg("-m")
 			.arg(timeout.unwrap_or(Duration::ZERO).as_secs_f64().to_string())
 			.arg("-g")
-			.arg(&url)
+			.arg(url)
 			.output()?;
 
 		if output.status.success() {

--- a/src/clients/powershell.rs
+++ b/src/clients/powershell.rs
@@ -11,7 +11,6 @@ impl ContainsSlice for [u8] {
 			return false;
 		}
 		(0..=self.len() - subslice.len())
-			.into_iter()
 			.any(|start| &self[start..start + subslice.len()] == subslice)
 	}
 }

--- a/src/clients/wget.rs
+++ b/src/clients/wget.rs
@@ -6,7 +6,7 @@ impl SystemHttpClientInterface for wget {
 	const COMMAND: &'static str = "wget";
 
 	fn get(&self, url: &str, timeout: Option<Duration>) -> Result<Response, Error> {
-		let output = spawn(Self::COMMAND).arg(format!("--timeout={}", timeout.unwrap_or(Duration::ZERO).as_secs_f64())).arg("--tries=1").args(&["-qO", "-"]).arg(&url).output()?;
+		let output = spawn(Self::COMMAND).arg(format!("--timeout={}", timeout.unwrap_or(Duration::ZERO).as_secs_f64())).arg("--tries=1").args(["-qO", "-"]).arg(url).output()?;
 		if output.status.success() {
 			Ok(Response {
 				body: output.stdout

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
 	IoError(std::io::Error),
 
 	/// The provided URL is invalid
+	#[cfg(feature = "validate")]
 	InvalidUrl(url::ParseError),
 
 	/// The URL must have a http or https scheme for security reasons
@@ -56,6 +57,7 @@ impl std::fmt::Display for Error {
 				write!(f, "This system does not have an HTTP client installed")
 			}
 			Error::IoError(e) => write!(f, "I/O error: {}", e),
+			#[cfg(feature = "validate")]
 			Error::InvalidUrl(e) => write!(f, "Invalid URL: {}", e),
 			Error::InvalidUrlScheme => write!(f, "URL must have http or https scheme"),
 			Error::CommandFailed { status, .. } => write!(f, "Process exited with code {status:?}"),
@@ -63,11 +65,14 @@ impl std::fmt::Display for Error {
 	}
 }
 impl std::error::Error for Error {}
+
+#[cfg(feature = "validate")]
 impl From<url::ParseError> for Error {
 	fn from(err: url::ParseError) -> Self {
 		Self::InvalidUrl(err)
 	}
 }
+
 impl From<std::io::Error> for Error {
 	fn from(err: std::io::Error) -> Self {
 		Self::IoError(err)

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,7 +1,16 @@
 pub trait ValidUrl: AsRef<str> {
+	#[cfg(feature = "validate")]
 	fn validate(&self) -> Result<&str, super::Error> {
 		let url = url::Url::parse(self.as_ref())?;
 		if matches!(url.scheme(), "http" | "https") {
+			Ok(self.as_ref())
+		} else {
+			Err(super::Error::InvalidUrlScheme)
+		}
+	}
+	#[cfg(not(feature = "validate"))]
+	fn validate(&self) -> Result<&str, super::Error> {
+		if self.as_ref().starts_with("http://") || self.as_ref().starts_with("https://") {
 			Ok(self.as_ref())
 		} else {
 			Err(super::Error::InvalidUrlScheme)


### PR DESCRIPTION
Thank you for this awesome crate!

I'm using this inside a build script and the request URL is static and trusted. However, the `url` dependency actually is quite heavy, introducing 9 dependencies into the tree.

I would like to make my builds as fast as possible, so preferably there should be a way for me to disable validation entirely.

This PR does just that - it makes the `url` dependency optional.

I've additionally ran cargo clippy and did some cleanups.

```
[build-dependencies]
└── sysreq v0.1.5
    └── url v2.3.1
        ├── form_urlencoded v1.1.0
        │   └── percent-encoding v2.2.0
        ├── idna v0.3.0
        │   ├── unicode-bidi v0.3.13
        │   └── unicode-normalization v0.1.22
        │       └── tinyvec v1.6.0
        │           └── tinyvec_macros v0.1.1
        └── percent-encoding v2.2.0
```